### PR TITLE
Add marketplace.json for plugin distribution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,39 @@
+{
+  "name": "creativestack",
+  "owner": {
+    "name": "Cameron Jones",
+    "email": "camawjones@gmail.com"
+  },
+  "metadata": {
+    "description": "AI skill suite for creative professionals. 29 skills across research, briefs, strategy, and project management.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "creativestack",
+      "source": {
+        "source": "github",
+        "repo": "camawjones/creativestack"
+      },
+      "description": "AI skill suite for creative professionals. 29 skills for research, briefs, strategy, and project management. Enhances the creative process — never generates creative output.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Cameron Jones",
+        "email": "camawjones@gmail.com"
+      },
+      "homepage": "https://jones.cam",
+      "repository": "https://github.com/camawjones/creativestack",
+      "license": "MIT",
+      "keywords": [
+        "creative",
+        "agency",
+        "freelancer",
+        "studio",
+        "branding",
+        "brief",
+        "strategy",
+        "project-management"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/marketplace.json` so CreativeStack can be distributed as a Claude Code plugin marketplace entry.

## Test plan
- [ ] Verify marketplace.json is valid JSON
- [ ] Verify plugin can be installed via the marketplace entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)