### PR TITLE
Add plain-english install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The skills adapt their language and flow based on what you are. A freelancer doe
 
 ## Installation
 
+Open your terminal app (Terminal on macOS, Windows Terminal or PowerShell on Windows, your usual terminal on Linux), paste the three lines below, and hit enter. They download CreativeStack into Claude Code's skills folder and run the installer that wires everything up. Takes about 30 seconds.
+
 ```bash
 git clone https://github.com/camawjones/creativestack.git ~/.claude/skills/creativestack
 cd ~/.claude/skills/creativestack
@@ -41,8 +43,6 @@ cd ~/.claude/skills/creativestack
 ```
 
 `./create` symlinks each skill's `SKILL.md` into `~/.claude/skills/<name>/SKILL.md` and each workflow agent into `~/.claude/agents/<name>.md`, so Claude Code discovers them as flat top-level entries. Restart Claude Code and all 29 skills and 4 agents are available — invoked flat as `/creative-brief`, `/meeting-notes`, `/competitor-audit`, and so on.
-
-The one skill with a non-obvious name is `/setup-brain` (renamed from `/setup` to avoid colliding with other skill stacks). Everything else matches its directory name.
 
 ### Updates
 


### PR DESCRIPTION
## Summary
- Adds a one-line, plain-English instruction above the install commands so creatives who haven't used a terminal before know what they're about to do
- Covers macOS, Windows, and Linux terminal apps
- Removes the leftover internal note about `/setup-brain`'s naming (same cleanup as the earlier CLAUDE.md/CHANGELOG.md pass)

## Test plan
- [ ] Render README on GitHub and confirm the new paragraph sits above the install code block
- [ ] Confirm the `/setup-brain` collision note is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)